### PR TITLE
Avoid useless loading of all files by augeas

### DIFF
--- a/manifests/server/config_entry.pp
+++ b/manifests/server/config_entry.pp
@@ -126,7 +126,7 @@ define postgresql::server::config_entry (
         }
         -> augeas { 'override PGPORT in /etc/sysconfig/pgsql/postgresql':
           lens    => 'Shellvars.lns',
-          incl    => '/etc/sysconfig/pgsql/*',
+          incl    => '/etc/sysconfig/pgsql/postgresql',
           context => '/files/etc/sysconfig/pgsql/postgresql',
           changes => "set PGPORT ${value}",
           require => File['/etc/sysconfig/pgsql/postgresql'],
@@ -145,7 +145,7 @@ define postgresql::server::config_entry (
         }
         -> augeas { 'override PGDATA in /etc/sysconfig/pgsql/postgresql':
           lens    => 'Shellvars.lns',
-          incl    => '/etc/sysconfig/pgsql/*',
+          incl    => '/etc/sysconfig/pgsql/postgresql',
           context => '/files/etc/sysconfig/pgsql/postgresql',
           changes => "set PGDATA ${value}",
           require => File['/etc/sysconfig/pgsql/postgresql'],


### PR DESCRIPTION
If in /etc/sysconfig/pgsql/postgresql there are files in a format other than bash style config , augeas will throw a warning: 
```
Warning: Augeas[override PGDATA in /etc/sysconfig/pgsql/postgresql](provider=augeas): Loading failed for one or more files, see debug for /augeas//error output
```
This commit fixes the issue.